### PR TITLE
add methods and notifications for communicating sync status

### DIFF
--- a/config.json
+++ b/config.json
@@ -90,9 +90,11 @@
         "syncfileend",
         "syncfileerr",
         "syncfileabort",
+        "syncfileprogress",
         "syncerr",
         "syncpurged",
-        "syncconflict"
+        "syncconflict",
+        "requestqueueinit"
       ]
     }
   }

--- a/lib/backends/rq/requestqueue.js
+++ b/lib/backends/rq/requestqueue.js
@@ -70,6 +70,17 @@ RequestQueue.prototype.getRequests = function (path, callback) {
 };
 
 /**
+ * Retrieves all requests that have been queued.
+ * @param {Function} callback Function to call with results of get operation.
+ * @param {String|Error} callback.err Error that occurred (will be falsy on success).
+ * @param {Array} callback.requests Array of objects representing the raw queued requests.
+ */
+RequestQueue.prototype.getAllRequests = function (callback) {
+  rqlog.debug('RequestQueue.getActiveRequests');
+  this.db.find({}).sort({timestamp: -1}).exec(callback);
+};
+
+/**
  * Retrieves a value indicating whether or not a given item exists in the queue.
  * @param {String} path The path of the item to check.
  * @param {String} name The name of the item to check.

--- a/lib/backends/rq/rqprocessor.js
+++ b/lib/backends/rq/rqprocessor.js
@@ -95,9 +95,11 @@ RQProcessor.prototype.abortUpload = function (itemPath) {
   if (self.activeRequests[itemPath]) {
     // cancel in-progress uploads if an item is updated
     logger.info('%s received a new request mid-upload. canceling upload.', itemPath);
-    self.activeRequests[itemPath].abort();
+
+    var file = self.activeRequests[itemPath].file;
+    self.activeRequests[itemPath].req.abort();
     self.activeRequests[itemPath] = undefined;
-    self.emit('syncabort', {file: itemPath});
+    self.emit('syncabort', {path: itemPath, file: file});
     return true;
   }
   return false;
@@ -127,7 +129,7 @@ RQProcessor.prototype.sync = function (config, cb) {
     };
     var handleError = function (path, method, err, immediateFail) {
       logger.error('encountered exception while attempting to process local file %s', path, err);
-      self.emit('syncerr', {file: path, method: method, err: err});
+      self.emit('syncerr', {path: refPath, file: path, method: method, err: err});
       removeActiveUpload();
       if (immediateFail) {
         self.rq.completeRequest(item.path, item.name, function (err) {
@@ -155,7 +157,7 @@ RQProcessor.prototype.sync = function (config, cb) {
       method = 'PUT';
     }
 
-    self.emit('syncstart', {file: path, method: method});
+    self.emit('syncstart', {path: refPath, file: path, method: method});
 
     if (url.match(/\/\./g)) {
       logger.warn('%s: attempt to sync path containing names beginning with a period', path);
@@ -182,7 +184,7 @@ RQProcessor.prototype.sync = function (config, cb) {
                 handleError(path, method, err);
               } else {
                 var endSync = function () {
-                  self.emit('syncend', {file: path, method: method});
+                  self.emit('syncend', {path: refPath, file: path, method: method});
                   self.sync(config, processCb);
                 };
                 removeActiveUpload();
@@ -206,9 +208,11 @@ RQProcessor.prototype.sync = function (config, cb) {
 
       if (method == 'POST' || method == 'PUT') {
         options.headers['content-type'] = utils.lookupMimeType(path);
-        var read;
+        var read, stats;
         try {
-          read = fs.createReadStream(self.unicodeNormalize(path));
+          var localPath = self.unicodeNormalize(path);
+          read = fs.createReadStream(localPath);
+          stats = fs.statSync(localPath);
         } catch (e) {
           handleError(path, method, e);
           return;
@@ -219,8 +223,27 @@ RQProcessor.prototype.sync = function (config, cb) {
         });
 
         var req = getRequest();
+
+        var totalRead = 0;
+        var lastCheck = 0;
+        var startTime = new Date().getTime();
+        var rate = 0;
+        read.on('data', function (chunk) {
+          totalRead += chunk.length;
+          var currCheck = new Date().getTime();
+          // determine byte rate per second
+          rate = Math.round(totalRead / ((currCheck - startTime) / 1000));
+          if ((currCheck - lastCheck) >= 1000) {
+            logger.debug('%s: read %d of %d bytes, upload %d percent complete, rate of %d bytes/sec', refPath, totalRead, stats.size, Math.round(totalRead / stats.size * 100), rate);
+            lastCheck = currCheck;
+            self.emit('syncprogress', {path: refPath, file: path, read: totalRead, total: stats.size, rate: rate});
+          }
+        });
+
         logger.debug('adding path %s to list of active uploads', refPath);
-        self.activeRequests[refPath] = req;
+        self.activeRequests[refPath] = {};
+        self.activeRequests[refPath].req = req;
+        self.activeRequests[refPath].file = path;
         read.pipe(req);
       } else {
         getRequest();

--- a/lib/backends/rq/tree.js
+++ b/lib/backends/rq/tree.js
@@ -61,6 +61,7 @@ var RQTree = function (share, remote, options) {
     path: share.config.work.path,
     db: options.rqdb
   });
+  share.emit('requestqueueinit', this.rq);
   this.processor = new RQProcessor(this, share.config);
 
   this.processor.on('syncstart', function (data) {
@@ -91,6 +92,11 @@ var RQTree = function (share, remote, options) {
   this.processor.on('syncabort', function (data) {
     logger.info('abort sync %s', data.file);
     share.emit('syncfileabort', data);
+  });
+
+  this.processor.on('syncprogress', function (data) {
+    logger.debug('sync progress %s', data.path);
+    share.emit('syncfileprogress', data);
   });
 
   if (!options.noprocessor) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-smb-server",
   "description": "A Pure JavaScript SMB Server Implementation",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "keywords": [
     "SMB",
     "CIFS",

--- a/spec/lib/test-common.js
+++ b/spec/lib/test-common.js
@@ -74,6 +74,7 @@ function TestCommon() {
       stream['pipe'] = function (other) {
         var pipeStream = new events();
         var emitEnd = function () {
+          stream.emit('data', [1, 2, 3, 4, 5]);
           if (!other.aborted) {
             if (other.emit) {
               other.emit('end');


### PR DESCRIPTION
The primary purpose of this pull request is to allow the request queue backend to communicate current status of its syncing process to external consumers. The consumer in this case needs to display a user interface listing the current status of all active and recent sync operations.