### PR TITLE
fix incorrect 404 responses for some existing folders

### DIFF
--- a/lib/backends/jcr/tree.js
+++ b/lib/backends/jcr/tree.js
@@ -207,8 +207,10 @@ JCRTree.prototype.exists = function (name, cb) {
 
   // there is a bug in the assets api when doing a HEAD request for a folder that
   // doesn't exist. we end up in a redirect loop. instruct the request not to follow redirects and assume
-  // that a redirect means that the url does not exist.
-  var url = this.share.buildResourceUrl(name);
+  // that a redirect means that the url does not exist. in addition, use the content url instead of
+  // the resource url due to sometimes receiving 302s even for folders that exist. using the content url
+  // correctly returns a 200 for these folders
+  var url = this.share.buildContentUrl(name);
   var options = this.share.applyRequestDefaults({
     url: url,
     method: 'HEAD',


### PR DESCRIPTION
This pull requests resolves an infrequent issue where some folders appear empty even though they contain assets. The resolution is to change the URL that the JCR backend uses when determining whether or not a path exists. The URL will now be the "content" URL, which is a URL that ends in the .json extension. In certain cases, using the resource's raw URL was resulting in a 302 response code from the API for folders that exist. Switching to the content URL correctly results in a 200 for folders that exist and 404 for folders that do not.

Note that this change is only for HEAD requests, which are used to determine existence of paths.