### PR TITLE
Network crash

### DIFF
--- a/lib/backends/jcr/tree.js
+++ b/lib/backends/jcr/tree.js
@@ -348,9 +348,11 @@ JCRTree.prototype.list = function (pattern, cb) {
   if (fileName === '*') {
     // wildcard pattern: list entries of parent path
     async.waterfall([ listTempFiles, listRemoteFiles ], function (err, result) {
-      cb(err, result.files);
       if (!err) {
+        cb(null, result.files);
         self.share.emit('folderlist', { path: parentPath, files: result.objs });
+      } else {
+        cb(err);
       }
     });
   } else {

--- a/lib/smb/handler.js
+++ b/lib/smb/handler.js
@@ -17,6 +17,7 @@ var path = require('path');
 
 var logger = require('winston').loggers.get('smb');
 var async = require('async');
+var domain = require('domain');
 
 var ntstatus = require('../ntstatus');
 var message = require('./message');
@@ -59,6 +60,27 @@ function handleRequest(msgBuf, connection, server, cb) {
 
   var msg = message.decode(msgBuf);
 
+  var d = domain.create();
+
+  d.on('error', function (err) {
+    logger.error('unhandled exception while handling request', err);
+    sendResponse(msg, ntstatus.STATUS_UNSUCCESSFUL, connection, server, cb);
+  });
+
+  d.run(function () {
+    _handleRequest(msg, connection, server, cb);
+  });
+}
+
+/**
+ * Handle binary CIFS/SMB 1.0 message
+ *
+ * @param {message} msg - decoded message
+ * @param {SMBConnection} connection - an SMBConnection instance
+ * @param {SMBServer} server - an SMBServer instance
+ * @param {Function} cb callback called on completion
+ */
+function _handleRequest(msg, connection, server, cb) {
   // invoke async command handlers
   async.eachSeries(msg.commands,
     function (cmd, callback) {

--- a/lib/smb2/handler.js
+++ b/lib/smb2/handler.js
@@ -14,7 +14,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var domain = require('domain');
 
 var logger = require('winston').loggers.get('smb');
 var put = require('put');
@@ -77,27 +76,6 @@ function handleRequest(msgBuf, connection, server, cb) {
     return;
   }
 
-  var d = domain.create();
-
-  d.on('error', function (err) {
-    logger.error('unhandled exception while handling request', err);
-    sendResponse(compMsgs[0], ntstatus.STATUS_UNSUCCESSFUL, connection, server, cb);
-  });
-
-  d.run(function () {
-    _handleRequest(compMsgs, connection, server, cb);
-  });
-}
-
-/**
- * Handles binary SMB 2.x/3.x messages
- *
- * @param {Array} compMsgs - processed compound messages
- * @param {SMBConnection} connection - an SMBConnection instance
- * @param {SMBServer} server - an SMBServer instance
- * @param {Function} cb callback called on completion
- */
-function _handleRequest(compMsgs, connection, server, cb) {
   var relatedOps = compMsgs.length > 1 && compMsgs[1].header.relatedOp;
 
   // context for related operations

--- a/lib/smb2/handler.js
+++ b/lib/smb2/handler.js
@@ -14,6 +14,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var domain = require('domain');
 
 var logger = require('winston').loggers.get('smb');
 var put = require('put');
@@ -76,6 +77,27 @@ function handleRequest(msgBuf, connection, server, cb) {
     return;
   }
 
+  var d = domain.create();
+
+  d.on('error', function (err) {
+    logger.error('unhandled exception while handling request', err);
+    sendResponse(compMsgs[0], ntstatus.STATUS_UNSUCCESSFUL, connection, server, cb);
+  });
+
+  d.run(function () {
+    _handleRequest(compMsgs, connection, server, cb);
+  });
+}
+
+/**
+ * Handles binary SMB 2.x/3.x messages
+ *
+ * @param {Array} compMsgs - processed compound messages
+ * @param {SMBConnection} connection - an SMBConnection instance
+ * @param {SMBServer} server - an SMBServer instance
+ * @param {Function} cb callback called on completion
+ */
+function _handleRequest(compMsgs, connection, server, cb) {
   var relatedOps = compMsgs.length > 1 && compMsgs[1].header.relatedOp;
 
   // context for related operations


### PR DESCRIPTION
Resolution to #39.

In addition, create and use a `domain` when processing a message so that uncaught exceptions like this will show in the log and won't crash the server.