### PR TITLE
Inconsistent Folder Contents

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,6 +38,7 @@
         "pass": "<pwd>"
       },
       "maxSockets": 64,
+      "allCacheTTL": 1800000,
       "contentCacheTTL": 30000,
       "binCacheTTL": 600000
     },
@@ -53,6 +54,7 @@
       },
       "path": "/",
       "maxSockets": 64,
+      "allCacheTTL": 1800000,
       "contentCacheTTL": 30000,
       "binCacheTTL": 600000
     },
@@ -67,6 +69,7 @@
         "pass": "<pwd>"
       },
       "maxSockets": 64,
+      "allCacheTTL": 1800000,
       "contentCacheTTL": 30000,
       "binCacheTTL": 600000,
       "expiration": 30000,

--- a/lib/backends/dam/share.js
+++ b/lib/backends/dam/share.js
@@ -65,6 +65,49 @@ DAMShare.prototype.isFolderClass = function (entity) {
 
 //-----------------------------------------------------------------< JCRShare >
 
+DAMShare.prototype.getContent = function (path, deep, cb) {
+  var self = this;
+  if (deep) {
+    // for folder lists, use default implementation
+    JCRShare.prototype.getContent.call(self, path, deep, cb);
+  } else {
+    // for individual entities, retrieve the parent's folder list and use the entity information from there.
+    // this is to avoid the need to make an extra HTTP request when retrieving information about individual items
+    var parent = utils.getParentPath(path);
+    var name = utils.getPathName(path);
+    self.getContent(parent, true, function (err, parentContent) {
+      if (err) {
+        cb(err);
+      } else {
+        if (parent == path) {
+          // it's the root path
+          cb(null, parentContent);
+        } else {
+          // find the entity in the parent's list of entities
+          var entities = parentContent[DAM.ENTITIES];
+          if (!entities) {
+            // no entities found, return null
+            cb(null, null);
+          } else {
+            var i;
+            var entityContent = null;
+            for (i = 0; i < entities.length; i++) {
+              if (entities[i][DAM.PROPERTIES]) {
+                var currName = entities[i][DAM.PROPERTIES][DAM.NAME];
+                if (currName == name) {
+                  entityContent = entities[i];
+                  break;
+                }
+              }
+            }
+            cb(null, entityContent);
+          }
+        }
+      }
+    });
+  }
+};
+
 DAMShare.prototype.parseContentChildEntries = function (content, iterator) {
   var self = this;
   var entities = content[DAM.ENTITIES] || [];

--- a/lib/backends/jcr/share.js
+++ b/lib/backends/jcr/share.js
@@ -61,6 +61,9 @@ var JCRShare = function (name, config) {
 
   this.description = config.description || '';
 
+  // TTL before all caches will be cleared
+  this.allCacheClear = Date.now();
+  this.allCacheTTL = typeof config.allCacheTTL === 'number' ? config.allCacheTTL : 1800000; // default: 30m
   // TTL in ms for content cache entries
   this.contentCacheTTL = typeof config.contentCacheTTL === 'number' ? config.contentCacheTTL : 30000; // default: 30s
   // TTL in ms for cached binaries
@@ -101,7 +104,14 @@ JCRShare.prototype.buildResourceUrl = function (path) {
 };
 
 JCRShare.prototype.getContent = function (path, deep, cb) {
-  // check cache
+  // clear all caches periodically to ensure that memory consumption remains in check
+  if (Date.now() - this.allCacheClear >= this.allCacheTTL) {
+    logger.debug('clearing all content caches');
+    this.cachedFolderListings = {};
+    this.cachedFileEntries = {};
+    this.cachedBinaries = {};
+    this.allCacheClear = Date.now();
+  }
   var cache = deep ? this.cachedFolderListings : this.cachedFileEntries;
   var result = cache[path];
   if (result) {

--- a/lib/backends/jcr/tree.js
+++ b/lib/backends/jcr/tree.js
@@ -167,12 +167,15 @@ JCRTree.prototype.createFileInstancesFromContent = function (content, path, name
                 addFile = false;
                 if (uniqueResults[uniqueName] < f.getName()) {
                   addFile = true;
+                  logger.warn('%s excluded from list because it is duplicate of %s', results[uniqueResults[uniqueName]].getPath(), f.getName());
                   delete results[uniqueResults[uniqueName]];
                 }
               }
               if (addFile) {
                 results[f.getName()] = f;
                 uniqueResults[uniqueName] = f.getName();
+              } else {
+                logger.warn('%s excluded from list because it is duplicate of %s', f.getPath(), uniqueResults[uniqueName]);
               }
             }
           }

--- a/lib/backends/jcr/tree.js
+++ b/lib/backends/jcr/tree.js
@@ -161,9 +161,19 @@ JCRTree.prototype.createFileInstancesFromContent = function (content, path, name
             // there are issues with paths containing names that begin with a period. technically these shouldn't end
             // up in JCR, but there have been cases where they're somehow created. if that's the case, exclude them
             // from the list to avoid future failures
-            if (!_isDotFile(f.getPath()) && !uniqueResults[uniqueName]) {
-              results[f.getName()] = f;
-              uniqueResults[uniqueName] = true;
+            if (!_isDotFile(f.getPath())) {
+              var addFile = true;
+              if (uniqueResults[uniqueName]) {
+                addFile = false;
+                if (uniqueResults[uniqueName] < f.getName()) {
+                  addFile = true;
+                  delete results[uniqueResults[uniqueName]];
+                }
+              }
+              if (addFile) {
+                results[f.getName()] = f;
+                uniqueResults[uniqueName] = f.getName();
+              }
             }
           }
           callback();

--- a/lib/backends/jcr/tree.js
+++ b/lib/backends/jcr/tree.js
@@ -132,6 +132,7 @@ JCRTree.prototype.createFileInstance = function (filePath, content, fileLength, 
  */
 JCRTree.prototype.createFileInstancesFromContent = function (content, path, namePattern, cb) {
   var results = {};
+  var uniqueResults = {};
   if (!content) {
     cb(null, {});
     return;
@@ -154,11 +155,15 @@ JCRTree.prototype.createFileInstancesFromContent = function (content, path, name
           callback(err);
         } else {
           if (f.getName()) {
+            // it's possible in JCR to have files with duplicate names - both EXACTLY the same name, and with
+            // paths that are the same except for case. For now, only display the first occurrence of a given file path
+            var uniqueName = f.getName().toLowerCase();
             // there are issues with paths containing names that begin with a period. technically these shouldn't end
             // up in JCR, but there have been cases where they're somehow created. if that's the case, exclude them
             // from the list to avoid future failures
-            if (!_isDotFile(f.getPath())) {
+            if (!_isDotFile(f.getPath()) && !uniqueResults[uniqueName]) {
               results[f.getName()] = f;
+              uniqueResults[uniqueName] = true;
             }
           }
           callback();

--- a/lib/backends/rq/tree.js
+++ b/lib/backends/rq/tree.js
@@ -391,19 +391,24 @@ function _convertRemoteToRqFile(data, cb) {
       cb(err);
     } else {
       async.each(remoteFiles, function (remoteFile, eachCb) {
-        if (existingRequests[tree.remoteEncodePath(remoteFile.getName())] != 'DELETE') {
-          tree.createFileInstanceFromOpen(remoteFile, function (err, newFile) {
-            if (err) {
-              eachCb(err);
-            } else {
-              data.rqFiles.push(newFile);
-              data.lookup[remoteFile.getName()] = data.rqFiles.length - 1;
-              eachCb();
-            }
-          });
-        } else {
-          // file has been deleted locally, ignore
+        if (tree.isTempFileName(remoteFile.getPath())) {
+          // don't include remote temp files in lists
           eachCb();
+        } else {
+          if (existingRequests[tree.remoteEncodePath(remoteFile.getName())] != 'DELETE') {
+            tree.createFileInstanceFromOpen(remoteFile, function (err, newFile) {
+              if (err) {
+                eachCb(err);
+              } else {
+                data.rqFiles.push(newFile);
+                data.lookup[remoteFile.getName()] = data.rqFiles.length - 1;
+                eachCb();
+              }
+            });
+          } else {
+            // file has been deleted locally, ignore
+            eachCb();
+          }
         }
       }, function (err) {
         if (err) {

--- a/spec/lib/backends/rq/tree-spec.js
+++ b/spec/lib/backends/rq/tree-spec.js
@@ -1162,6 +1162,23 @@ describe('RQTree', function () {
         });
       });
     });
+
+    iit('testListRemoteTempFile', function (done) {
+      c.addFile(c.remoteTree, '/.temp', function () {
+        c.testTree.list('/*', function (err, list) {
+          expect(err).toBeFalsy();
+          expect(list.length).toEqual(0);
+          c.testTree.list('/.temp', function (err, list) {
+            expect(err).toBeFalsy();
+            expect(list.length).toEqual(0);
+            c.testTree.exists('/.temp', function (err, exists) {
+              expect(exists).toBeFalsy();
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('ConcurrencyTests', function () {

--- a/spec/lib/backends/rq/tree-spec.js
+++ b/spec/lib/backends/rq/tree-spec.js
@@ -1163,7 +1163,7 @@ describe('RQTree', function () {
       });
     });
 
-    iit('testListRemoteTempFile', function (done) {
+    it('testListRemoteTempFile', function (done) {
       c.addFile(c.remoteTree, '/.temp', function () {
         c.testTree.list('/*', function (err, list) {
           expect(err).toBeFalsy();


### PR DESCRIPTION
This pull request contains fixes for issues #46, #47, and #48. Here is a summary of the changes:

* Added a cache-level TTL so that all JCR content caches are cleared periodically to prevent continuous growth over time
* In the case of duplicate file paths (case insensitive), only include the first occurrence of a file name in directory lists
* Exclude temporary file names from DAM directory lists